### PR TITLE
Add TimeRange class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ lib
 lib64
 
 MANIFEST
+.coverage
+htmlcov

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,6 @@
+2013-12-28  Björn Andersson  <ba@sanitarium.se>
+
+	* datetime_periods/time_range.py (TimeRange): Add TimeRange class
+	to smartly handle ranges of time. Main example is opening hours a
+	location opens at 17:00 and closes at 03:00, it closes at another
+	date.

--- a/README.rst
+++ b/README.rst
@@ -2,10 +2,13 @@
 datetime_periods
 ================
 
+.. image:: https://travis-ci.org/mediapop/datetime_periods.png
+           :target: https://travis-ci.org/mediapop/datetime_periods
+
 This module aims to help you create time periods as easily as if by a
 snap of your finger.
 
-Pass in a :py:mod:`datetime.datetime()` object and a period name and it'll
+Pass in a `datetime.datetime()` object and a period name and it'll
 return the beginning and end of that period.
 
 Documentation available on `Read the Docs`_.
@@ -20,8 +23,11 @@ You can install from pypi!
     pip install datetime_periods
 
 
-Usage:
+`period` usage
 ------
+
+Pass in a `datetime.datetime()` object and a period name and it'll
+return the beginning and end of that period.
 
 .. code-block::
 
@@ -44,6 +50,37 @@ Usage:
     [datetime(2012, 1, 1), datetime(2012, 12, 31, 23, 59, 59)]
 
 
+`TimeRange` usage
+------
+
+The `TimeRange` class takes two times, `start` and `stop`, and creates
+`datetime` objects from them that is smart about when a date should
+roll over to the following day.
+
+This class can also act like a 2 length list where index 0=start,
+1=stop time. This to allow the class to be used for argument
+expansion and as an iterator.
+
+.. code-block::
+
+    >>> from datetime_periods import TimeRange
+    >>> tr = TimeRange('17:00', '23:00', '2013-12-25')
+    >>> tr.start
+    datetime(2013, 12, 25, 17)
+    >>> tr.stop
+    datetime(2013, 12, 25, 23)
+    >>> tr = TimeRange('17:00', '04:00', '2013-12-25')
+    >>> tr.start
+    datetime(2013, 12, 25, 17)
+    >>> tr.stop
+    datetime(2013, 12, 26, 4)
+    >>> tr[0] == tr.start
+    True
+    >>> tr[1] == tr.stop
+    True
+
+Sugar
+-----
 
 The `sugar` module has sugar functions for all variants available.
 

--- a/datetime_periods/__init__.py
+++ b/datetime_periods/__init__.py
@@ -1,1 +1,2 @@
 from .period import period_beginning, period_end, period
+from .time_range import TimeRange

--- a/datetime_periods/period.py
+++ b/datetime_periods/period.py
@@ -1,5 +1,5 @@
 from datetime_truncate import truncate as period_beginning
-from period_end import period_end
+from .period_end import period_end
 
 
 def period(datetime, period_name='day'):

--- a/datetime_periods/sugar.py
+++ b/datetime_periods/sugar.py
@@ -1,6 +1,7 @@
 from datetime_truncate import truncate
-from period import period
-from period_end import period_end
+
+from .period import period
+from .period_end import period_end
 
 
 def period_second(datetime):

--- a/datetime_periods/time_range.py
+++ b/datetime_periods/time_range.py
@@ -1,0 +1,123 @@
+from datetime import datetime, timedelta
+
+from dateutil.parser import parse
+import six
+
+
+class TimeRange(object):
+    """Takes two times, ``start`` and ``stop``, and tries to be
+    smart about putting a date to those times.
+
+    Stop is always assumed to follow start in chronological order, so
+    if stop is numerically less than start then it must be tomorrow.
+
+    Strings are parsed with ``dateutil.parser`` from the
+    `python-dateutil` package.
+
+    This class can also act like a 2 length list where index 0=start,
+    1=stop time. This to allow the class to be used for argument
+    expansion and as an iterator.
+
+    Examples::
+
+        >>> tr = TimeRange('17:00', '23:00', '2013-12-25')
+        >>> tr.start
+        datetime(2013, 12, 25, 17)
+        >>> tr.stop
+        datetime(2013, 12, 25, 23)
+        >>> tr = TimeRange('17:00', '04:00', '2013-12-25')
+        >>> tr.start
+        datetime(2013, 12, 25, 17)
+        >>> tr.stop
+        datetime(2013, 12, 26, 4)
+        >>> tr[0] == tr.start
+        True
+        >>> tr[1] == tr.stop
+        True
+
+    :param start: a ``time`` object or a time string
+    :param stop: a ``time`` object or a time string
+    :param date: a ``datetime``, ``date``, or date string
+    :param tzinfo: None or a tzinfo that will replace the current one
+                   in the ``timestamp`` attributes ``start`` and ``stop``
+
+    """
+    def __init__(self, start, stop, date=None, tzinfo=None):
+        self.date = self._ensure_date(date)
+        self.tzinfo = tzinfo
+
+        self.time = {
+            'start': self._ensure_time(start),
+            'stop': self._ensure_time(stop),
+        }
+
+        self._timestamps()
+
+    def _timestamps(self):
+        self.timestamp = {}
+        start, stop = self.time['start'], self.time['stop']
+
+        self.timestamp['start'] = datetime.combine(self.date, start)
+        self.timestamp['stop'] = datetime.combine(self.date, stop)
+
+        if stop <= start:
+            self.timestamp['stop'] = self.timestamp['stop'] + timedelta(days=1)
+
+        if self.tzinfo:
+            for k, v in self.timestamp.items():
+                self.timestamp[k] = v.replace(tzinfo=self.tzinfo)
+
+    def _ensure_date(self, date):
+        if not date:
+            date = datetime.now()
+        elif isinstance(date, six.string_types):
+            date = parse(date, yearfirst=True)  # ISO8601 dates ftw
+
+        try:
+            return date.date()
+        except AttributeError:
+            return date
+
+    def _ensure_time(self, timestamp):
+        if isinstance(timestamp, six.string_types):
+            timestamp = parse(timestamp)
+
+        try:
+            return timestamp.time()
+        except AttributeError:
+            return timestamp
+
+    def __getitem__(self, key):
+        if key == 0:
+            return self.start
+        elif key == 1:
+            return self.stop
+        else:
+            raise KeyError
+
+    def __iter__(self):
+        return iter((self.start, self.stop))
+
+    def __repr__(self):
+        return('{cls}(start={start}, stop={stop}, '
+               'date={date}, tzinfo={tzinfo})').format(
+            cls=self.__class__.__name__,
+            start=self.time['start'].__repr__(),
+            stop=self.time['stop'].__repr__(),
+            date=self.date.__repr__(),
+            tzinfo=self.tzinfo.__repr__(),
+        )
+
+    @property
+    def start(self):
+        """The inserted ``start`` as a timestamp, if ``tzinfo`` was passed in
+        it'll be set
+        """
+        return self.timestamp['start']
+
+    @property
+    def stop(self):
+        """The inserted ``stop`` as a timestamp, if ``tzinfo`` was passed in
+        it'll be set
+        """
+        return self.timestamp['stop']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,11 +6,11 @@ datetime_periods
 This module aims to help you create time periods as easily as if by a
 snap of your finger.
 
+`period` usage:
+------
+
 Pass in a :py:mod:`datetime.datetime()` object and a period name and it'll
 return the beginning and end of that period.
-
-Usage:
-------
 
     >>> from datetime_periods import period
     >>> period(datetime(2012, 4, 2, second=12), 'minute')
@@ -31,7 +31,39 @@ Usage:
     [datetime(2012, 1, 1), datetime(2012, 12, 31, 23, 59, 59)]
 
 
-The `sugar` module has sugar functions for all variants available.
+`TimeRange` usage:
+------
+
+The :py:class:`TimeRange <datetime_periods.TimeRange>` class takes two
+times, `start` and `stop`, and creates `datetime` objects from them
+that is smart about when a date should roll over to the following day.
+
+This class can also act like a 2 length list where index 0=start,
+1=stop time. This to allow the class to be used for argument
+expansion and as an iterator.
+
+    >>> from datetime_periods import TimeRange
+    >>> tr = TimeRange('17:00', '23:00', '2013-12-25')
+    >>> tr.start
+    datetime(2013, 12, 25, 17)
+    >>> tr.stop
+    datetime(2013, 12, 25, 23)
+    >>> tr = TimeRange('17:00', '04:00', '2013-12-25')
+    >>> tr.start
+    datetime(2013, 12, 25, 17)
+    >>> tr.stop
+    datetime(2013, 12, 26, 4)
+    >>> tr[0] == tr.start
+    True
+    >>> tr[1] == tr.stop
+    True
+
+Sugar
+-----
+
+The :py:mod:`sugar <datetime_periods.sugar>` module has sugar
+functions for all :py:func:`period <datetime_periods.period>` variants
+available.
 
 Sugar functions for entire period:
 
@@ -69,9 +101,10 @@ Sugar functions for end of period:
 * `period_end_half_year`
 * `period_end_year`
 
-
 :mod:`datetime_periods`
 ------------------------------------------
+
+.. autoclass:: datetime_periods.TimeRange
 
 .. autofunction:: datetime_periods.period
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
 nose>=1.2.1
+coverage>=3.6

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='datetime_periods',
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/mediapop/datetime_periods',
     author='Björn Andersson / Media Pop',
     author_email='bjorn@mediapop.co',

--- a/tests/test_time_range.py
+++ b/tests/test_time_range.py
@@ -1,0 +1,98 @@
+from datetime import date, datetime, time, timedelta
+from unittest import TestCase
+
+from datetime_periods import TimeRange
+from dateutil.tz import tzutc
+
+
+class TimeRangeTest(TestCase):
+    def setUp(self):
+        self.now = datetime.now()
+        self.date = self.now.date()
+        self.start, self.stop = time(17), time(23)
+
+    def combine(self, time, add_day=False, tzinfo=None):
+        timestamp = datetime.combine(self.date, time)
+        if tzinfo:
+            timestamp = timestamp.replace(tzinfo=tzinfo)
+
+        if add_day:
+            return timestamp + timedelta(days=1)
+        else:
+            return timestamp
+
+    def test_simple_times_after_each_other_should_work(self):
+        start, stop = time(19), time(23, 30)
+
+        tr = TimeRange(start, stop)
+        self.assertEqual(tr.start, self.combine(start))
+        self.assertEqual(tr.stop, self.combine(stop))
+
+    def test_simple_times_where_stop_reaches_into_tomorrow_should_work(self):
+        start, stop = time(17), time(1)
+
+        tr = TimeRange(start, stop)
+        self.assertEqual(tr.start, self.combine(start))
+        self.assertEqual(tr.stop, self.combine(stop, add_day=True))
+
+    def test_same_time_on_both_start_stop_should_end_tomorrow(self):
+        start, stop = time(0), time(0)
+
+        tr = TimeRange(start, stop)
+        self.assertEqual(tr.start, self.combine(start))
+        self.assertEqual(tr.stop, self.combine(stop, add_day=True))
+
+    def test_time_should_be_passable_as_a_string(self):
+        tr = TimeRange('17:00', '23:00')
+        self.assertEqual(tr.start, self.combine(self.start))
+        self.assertEqual(tr.stop, self.combine(self.stop))
+
+    def test_date_should_be_passable_as_string(self):
+        tr = TimeRange('17:00', '23:00', '2013-12-25')
+        self.date = date(2013, 12, 25)
+        self.assertEqual(tr.start, self.combine(self.start))
+        self.assertEqual(tr.stop, self.combine(self.stop))
+
+    def test_date_should_be_passable_as_date(self):
+        tr = TimeRange('17:00', '23:00', self.now.date())
+        self.assertEqual(tr.start, self.combine(self.start))
+        self.assertEqual(tr.stop, self.combine(self.stop))
+
+    def test_should_set_tzinfo_to_correct(self):
+        tr = TimeRange(self.start, self.stop, tzinfo=tzutc())
+        self.assertEqual(tr.start, self.combine(self.start, tzinfo=tzutc()))
+        self.assertEqual(tr.stop, self.combine(self.stop, tzinfo=tzutc()))
+
+        # It should just set the timezone, not convert between timezones
+        self.assertEqual(tr.start.time(), self.start)
+        self.assertEqual(tr.stop.time(), self.stop)
+
+    def test_class_should_be_accessible_as_list(self):
+        # Where 0=start, 1=stop
+        tr = TimeRange(self.start, self.stop)
+        self.assertEqual(tr[0], self.combine(self.start))
+        self.assertEqual(tr[1], self.combine(self.stop))
+
+    def test_class_should_not_allow_other_values_than_01_for_list_access(self):
+        tr = TimeRange(self.start, self.stop)
+
+        # assertRaises is not available as a context manager in 2.6,
+        # so lets be creative.
+        self.assertRaises(KeyError, lambda k: tr[k], -1)
+        self.assertRaises(KeyError, lambda k: tr[k], 2)
+
+    def test_should_allow_splatting_keys_for_the_timestamps(self):
+        tr = TimeRange(self.start, self.stop)
+        start, stop = tr
+
+        self.assertEqual(start, self.combine(self.start))
+        self.assertEqual(stop, self.combine(self.stop))
+
+    def test___repr___should_show_reasonable_info_to_reproduce(self):
+        tr = TimeRange(self.start, self.stop, '2013-12-25')
+        self.assertEqual(
+            tr.__repr__(),
+            'TimeRange(start=datetime.time(17, 0), '
+            'stop=datetime.time(23, 0), '
+            'date=datetime.date(2013, 12, 25), tzinfo=None)'
+        )


### PR DESCRIPTION
TimeRange class added to handle adding a date to two times and adding
the correct date even when the time should roll over to a new day.

The primary use case for this class is when you have opening hours and the closing time might roll over into the next day.

For instance:

```
opening_hour = '17:00'
closing_hour = '03:00'
date = '2013-12-24'

timestamp_opening = '2013-12-24 17:00:00'
timestamp_closing = '2013-12-25 03:00:00'
```

The Travis build is failing because I haven't gotten Travis setup correctly yet.
